### PR TITLE
Use a temp work dir when installing

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,12 +34,20 @@ install_java() {
 	local versionstr=$1
 	local destdir=$2
 
-	IFS=- read distro version <<< $versionstr
+	IFS=- read -r distro version <<< "${versionstr}"
 
 	local variant=$(get_variant $distro)
 	[[ -z "$ASDF_JAVA_ERROR" ]] || return
 
-	get_java $distro $version $variant $destdir
+	# Perform all operations is a temporary directory that will be
+	# automatically cleaned up on exit (success or failure).
+	local wrkdir
+	wrkdir=$(mktemp -dt asdf-java.XXXXXX)
+	# shellcheck disable=SC2064
+	trap "cd ${PWD}; rm -rf ${wrkdir}" EXIT
+	cd "${wrkdir}"
+
+	get_java "${distro}" "${version}" "${variant}"
 	[[ -z "$ASDF_JAVA_ERROR" ]] || return
 
 	unpack_java $variant $destdir
@@ -112,7 +120,6 @@ get_java() {
 	local distro=$1
 	local version=$2
 	local variant=$3
-	local destdir=$4
 
 	local base=$(get_base_url $distro)
 	local oracle8_version=$(echo $version | sed -e 's|\.|u|g')
@@ -140,7 +147,7 @@ get_java() {
 		--progress-bar \
 		--retry 3 --retry-delay 3 \
 		-b oraclelicense=accept-securebackup-cookie \
-		-o $destdir/$variant $url
+		-o ./$variant $url
 
 	[[ $? != 0 ]] && ASDF_JAVA_ERROR="downloading java dist"
 }
@@ -152,6 +159,7 @@ unpack_java() {
 
 	log_info expanding java dist
 
+	mkdir -p "${destdir}"
 	case $variant in
 		*.tar.gz) unpack_tar $variant $destdir ;;
 		*.dmg)    unpack_dmg $variant $destdir ;;
@@ -162,66 +170,47 @@ unpack_java() {
 
 # Unarchive a tar archive into the install directory and cleanup.
 #
-# NOTE: Using $origin as a memo rather than executing in a subshell
-#   because errors won't be persisted from a subshell.
-#
 # TODO: Should be sanitized with error reporting.
 unpack_tar() {
-	local variant=$1
+	local archive=$1
 	local destdir=$2
 
-	local origin=$(pwd)
-	cd $destdir; {
-		tar -xzf $variant
-		[[ $? == 0 ]] || ASDF_JAVA_ERROR="expanding java dist"
-		rm $variant
+	tar -xzf "${archive}" \
+		|| { ASDF_JAVA_ERROR="expanding java dist"; return; }
 
-		local pkg=$(echo * | grep jdk)
-		if [ -d $pkg/Contents/Home ]; then
-			mv $pkg/Contents/Home/* .
-		else
-			mv $pkg/* .
-		fi
-		rmdir $pkg
-	}; cd $origin
+	local jdk_dir
+	jdk_dir=$(echo ./*jdk*)
+	if [[ -d ${jdk_dir}/Contents/Home ]]; then
+		jdk_dir="${jdk_dir}/Contents/Home"
+	fi
+	mv "${jdk_dir}"/* "${destdir}/"
 }
 
 # Unarchive a tar archive into the install directory and cleanup.
 #
-# NOTE: Using $origin as a memo rather than executing in a subshell
-#   because errors won't be persisted from a subshell.
-#
 # TODO: Should be sanitized with error reporting.
 unpack_dmg() {
-	local variant=$1
+	local image=$1
 	local destdir=$2
 
-	local origin=$(pwd)
-	cd $destdir; {
-		local pkgdir=$destdir/asdf_tmp_pkgdir
-		local imgdir=$destdir/asdf_tmp_imgdir
+	local pkgdir=./asdf_tmp_pkgdir
+	local imgdir=./asdf_tmp_imgdir
 
-		mount_dmg $imgdir $variant
-		[[ -z "$ASDF_JAVA_ERROR" ]] || return
+	mount_dmg $imgdir $image
+	[[ -z "$ASDF_JAVA_ERROR" ]] || return
 
-		pkgutil --expand $imgdir/*.pkg $pkgdir
-		if [[ $? != 0 ]]; then
-			ASDF_JAVA_ERROR="expanding java dist"
-			unmount_dmg $imgdir
-			return
-		fi
+    if pkgutil --expand $imgdir/*.pkg $pkgdir; then
+        if gzip -dc < ${pkgdir}/jdk*.pkg/Payload | cpio -i \
+                && [[ -d Contents ]]; then
+            mv Contents/Home/* $destdir/
+        else
+            ASDF_JAVA_ERROR="demangling dist payload"
+        fi
+    else
+        ASDF_JAVA_ERROR="expanding java dist"
+    fi
 
-		cd $pkgdir/jdk*.pkg; {
-			cat Payload | gzip -d | cpio -i
-			if [[ $? != 0 ]] || ! [[ -d Contents ]]; then
-				ASDF_JAVA_ERROR="demangling dist payload"
-			fi
-			mv Contents/Home/* $destdir/
-		}; cd $destdir
-
-		unmount_dmg $imgdir
-		rm -r $destdir/$variant
-	}; cd $origin
+    unmount_dmg "${imgdir}"
 }
 
 mount_dmg() {


### PR DESCRIPTION
Create and automatically clean-up a temporary directory.

This makes the process compliant with asdf requirements  to avoid
writing to `ASDF_INSTALL_PATH` until the download, extraction and build
are done to avoid racing with other processes trying to access the JDK.
https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#bininstall

Since the directory is automatically cleaned up on exit, functions that
extract the archives don't need to worry about cleaning up individual
files as long as they are written to the working directory.

Also fix a problem with word splitting of `versionstr` - if unquoted,
the value is split by the shell before passing it to `read` which meant
that `distro` was actually being assigned DISTRO SPACE VERSION and
version was an empty string, it only worked further down coincidentally
because the variables weren't quoted so `distro` was subject to word
splitting before being passed to `get_java` and `unpack_java`.