### PR TITLE
add mac_hotspot case to statement in unpack_java function

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -172,7 +172,7 @@ unpack_java() {
 
         mkdir -p "${destdir}"
 	case $variant in
-		*linux_hotspot | *.tar.gz) unpack_tar $variant $destdir ;;
+		*linux_hotspot | *.tar.gz | *mac_hotspot) unpack_tar $variant $destdir ;;
 		*.dmg)    unpack_dmg $variant $destdir ;;
                 *.zip)    unpack_zip $variant $destdir ;;
 		*) ASDF_JAVA_ERROR="$variant is not supported" ;;


### PR DESCRIPTION
For `adoptopenjdk` installs the `$variant` is set to `mac_hotspot`.

The `unpack_java` function uses the `$variant` value to determine how to install and had a case statement with no way of handling `mac_hotspot`. So `adoptopenjdk` will automatically fail.

This PR should fix that.