### PR TITLE
update JAVA_HOME without running asdf

### DIFF
--- a/asdf-java-wrapper.bash
+++ b/asdf-java-wrapper.bash
@@ -1,12 +1,10 @@
 # Credit: github.com/trustin
 asdf_java_wrapper() {
-  if \asdf "$@"; then
-    if [[ "$(\asdf current java 2>&1)" =~ "(^([-_.a-zA-Z0-9]+)[[:space:]]*\(set by.*$)" ]]; then
-      export JAVA_HOME=$(\asdf where java ${BASH_REMATCH[2]})
-    else
-      export JAVA_HOME=''
-    fi
+  if [[ "$(\asdf current java 2>&1)" =~ "(^([-_.a-zA-Z0-9]+)[[:space:]]*\(set by.*$)" ]]; then
+    export JAVA_HOME=$(\asdf where java ${BASH_REMATCH[2]})
+  else
+    export JAVA_HOME=''
   fi
 }
 
-alias asdf='asdf_java_wrapper'
+asdf_java_wrapper

--- a/asdf-java-wrapper.zsh
+++ b/asdf-java-wrapper.zsh
@@ -1,12 +1,10 @@
 # Credit: github.com/trustin
 asdf_java_wrapper() {
-  if \asdf "$@"; then
-    if [[ "$(\asdf current java 2>&1)" =~ "^([-_.a-zA-Z0-9]+)[[:space:]]*\(set by.*$" ]]; then
-      export JAVA_HOME=$(\asdf where java ${match[1]})
-    else
-      export JAVA_HOME=''
-    fi
+  if [[ "$(\asdf current java 2>&1)" =~ "^([-_.a-zA-Z0-9]+)[[:space:]]*\(set by.*$" ]]; then
+    export JAVA_HOME=$(\asdf where java ${match[1]})
+  else
+    export JAVA_HOME=''
   fi
 }
 
-alias asdf='asdf_java_wrapper'
+asdf_java_wrapper


### PR DESCRIPTION
When using java wrapper, the env variable $JAVA_HOME is not populated if you don't run asdf in the current shell session

What would be great is to populate JAVA_HOME each time I launch a new shell 