### PR TITLE
Update Amazon Corretto JDKs

### DIFF
--- a/corretto/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+aaf35f707ea12f5942c72ba70192444de19c4e1c7f5546ce2a0725093dde6fba  amazon-corretto-11.0.4.11.1-linux-x64.tar.gz

--- a/corretto/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+739ccf56290999d1e81b0f9c1fe68f62ed64e98caa248527453e6e6652ba2d13  amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz

--- a/corretto/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+4cc9e65e6e3d036b18cfd5fd6c7843d48244e44a60350f7e45036f4825bd3812  amazon-corretto-11.0.5.10.1-linux-x64.tar.gz

--- a/corretto/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+e806d2eb7f66b142ba2106d91b9ef3cfbec30c865eb65a2e7ec9fd9e2bb21aa9  amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz

--- a/corretto/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+d0a26ae0d0c92c52529c4fb51a28d577f7a7e42b238cef966eb6d9b3509eaf1f  amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz

--- a/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+aae628b8ed68d88f68e1a8b34e32c35231a68159dec468d5ab5e7ac9a5b35c1f  amazon-corretto-8.232.09.2-macosx-x64.tar.gz

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -60,5 +60,18 @@
         "heap_size": "normal",
         "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.3.7.1-macosx-x64.tar.gz.sha256.txt"
       }]
+  },
+  {
+    "release_name": "amazon-corretto-8.232.09.2",
+    "binaries": [
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/8.232.09.2/amazon-corretto-8.232.09.2-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt"
+      }
+    ]
   }
 ]

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -95,6 +95,26 @@
       }]
   },
   {
+    "release_name": "amazon-corretto-11.0.5.10.1",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/11.0.5.10.1/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz.sha256.txt"
+      }]
+  },
+  {
     "release_name": "amazon-corretto-11.0.5.10.2",
     "binaries": [
       {

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -75,6 +75,26 @@
     ]
   },
   {
+    "release_name": "amazon-corretto-11.0.4.11.1",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz.sha256.txt"
+      }]
+  },
+  {
     "release_name": "amazon-corretto-11.0.5.10.2",
     "binaries": [
       {

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -73,5 +73,17 @@
         "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt"
       }
     ]
+  },
+  {
+    "release_name": "amazon-corretto-11.0.5.10.2",
+    "binaries": [
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/11.0.5.10.2/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz.sha256.txt"
+      }]
   }
 ]

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -42,6 +42,19 @@
     ]
   },
   {
+    "release_name": "amazon-corretto-8.232.09.2",
+    "binaries": [
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/8.232.09.2/amazon-corretto-8.232.09.2-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt"
+      }
+    ]
+  },
+  {
     "release_name": "amazon-corretto-11.0.3.7.1",
     "binaries": [
       {
@@ -60,19 +73,6 @@
         "heap_size": "normal",
         "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.3.7.1-macosx-x64.tar.gz.sha256.txt"
       }]
-  },
-  {
-    "release_name": "amazon-corretto-8.232.09.2",
-    "binaries": [
-      {
-        "os": "mac",
-        "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/8.232.09.2/amazon-corretto-8.232.09.2-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt"
-      }
-    ]
   },
   {
     "release_name": "amazon-corretto-11.0.4.11.1",


### PR DESCRIPTION
* Add Corretto 8.232.09.2 (macOS only)
* Add Corretto 11.0.4.11.1
* Add Corretto 11.0.5.10.1
* Add Corretto 11.0.5.10.2 (macOS only)