### PR TITLE
Fix the GitHub tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,16 @@ jobs:
     env:
       TERM: dumb
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: mstksg/get-package@v1
       with:
         brew: coreutils
     - name: Install asdf
-      run: git clone --quiet https://github.com/asdf-vm/asdf.git
+      uses: actions/checkout@v2
+      with:
+        repository: asdf-vm/asdf
+        path: asdf
     - name: Run tests
       run: |
         . asdf/asdf.sh
-        asdf plugin-test java $GITHUB_WORKSPACE
+        asdf plugin-test java "$GITHUB_WORKSPACE" --asdf-plugin-gitref "$GITHUB_SHA"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test java $TRAVIS_BUILD_DIR
+script: asdf plugin-test java "$TRAVIS_BUILD_DIR" --asdf-plugin-gitref "$TRAVIS_COMMIT"
 before_script:
 - git clone https://github.com/asdf-vm/asdf.git
 - . asdf/asdf.sh


### PR DESCRIPTION
Explicitly use the current git commit for running `asdf plugin-test`.

Otherwise, asdf will try to use the "master" branch for running its tests:
https://github.com/asdf-vm/asdf/blob/v0.7.6/lib/commands/command-plugin-test#L9