### PR TITLE
Add Zulu 7.36.0.5, 8.44.0.9, 11.37.17, 13.29.9

### DIFF
--- a/zulu/zulu.json
+++ b/zulu/zulu.json
@@ -1,5 +1,26 @@
 [
   {
+    "release_name": "azul-zulu-13.29.9-jdk13.0.2",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz.sha256.txt"
+      }
+    ]
+  },
+  {
     "release_name": "azul-zulu-13.28.11-jdk13.0.1",
     "binaries": [
       {
@@ -123,6 +144,26 @@
       }]
   },
   {
+    "release_name": "azul-zulu-11.37.17-jdk11.0.6",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz.sha256.txt"
+      }]
+  },
+  {
     "release_name": "azul-zulufx-11.35.15-jdk11.0.5",
     "binaries": [
       {
@@ -160,6 +201,26 @@
         "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz",
         "heap_size": "normal",
         "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
+      }]
+  },
+  {
+    "release_name": "azul-zulu-8.44.0.9-jdk8.0.242",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
       }]
   },
   {
@@ -232,6 +293,26 @@
         "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.34.0.5-ca-jdk7.0.242-macosx_x64.tar.gz",
         "heap_size": "normal",
         "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.34.0.5-ca-jdk7.0.242-macosx_x64.tar.gz.sha256.txt"
+      }]
+  },
+  {
+    "release_name": "azul-zulu-7.36.0.5-jdk7.0.252",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz.sha256.txt"
       }]
   }
 ]

--- a/zulu/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz.sha256.txt
+++ b/zulu/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1  zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz

--- a/zulu/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz.sha256.txt
+++ b/zulu/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f  zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz

--- a/zulu/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz.sha256.txt
+++ b/zulu/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+ecb3f9626a9bc810daeb0f4e7d69474b7ae19fe0634658713e009ca6b1f1be98  zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz

--- a/zulu/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz.sha256.txt
+++ b/zulu/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+ee86200843b38b263fd547982e99cabb491a3ecf6d9dc8f38f410184fa5012f5  zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz

--- a/zulu/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz.sha256.txt
+++ b/zulu/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+e0f34c242e6d456dac3e2c8a9eaeacfa8ea75c4dfc3e8818190bf0326e839d82  zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz

--- a/zulu/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz.sha256.txt
+++ b/zulu/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+06231394d07faebffe388f6cbd0821db9a6cc6180a9b2f92e00c448d9f21c1d5  zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz

--- a/zulu/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt
+++ b/zulu/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+7731f08723cac4ad3d5e2fab4e80b275577ecf07a174033fdda5fc8bdaddaeea  zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz

--- a/zulu/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt
+++ b/zulu/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+5855443780e71f3b74cdd6f644010abb9c3be7c185474f0ecaedd5271be46f63  zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz


### PR DESCRIPTION
Add latest versions of the Zulu OpenJDK 7, 8, 11, and 13 from Azul.