### PR TITLE
Add Corretto 8.242.08.1 and 11.0.6.10.1-2

### DIFF
--- a/corretto/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+c45847a8d149810afecad148628d9eeb93bff163f916881bf41a832fef2232a0  amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz

--- a/corretto/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+bf355486b4b9902fc4a5e68de9e56fe8341a7943e0ef90b6b2939a04809e12f8  amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz

--- a/corretto/amazon-corretto-8.242.08.1-linux-x64.tar.gz.sha256.txt
+++ b/corretto/amazon-corretto-8.242.08.1-linux-x64.tar.gz.sha256.txt
@@ -1,0 +1,1 @@
+e302fbd2d7354a2a8c5fa7491f4de1d73967104078da9671abada260b2f02fcd  amazon-corretto-8.242.08.1-linux-x64.tar.gz

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -76,6 +76,27 @@
     ]
   },
   {
+    "release_name": "amazon-corretto-8.242.08.1",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/8.242.08.1/amazon-corretto-8.242.08.1-linux-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.08.1-linux-x64.tar.gz.sha256.txt"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/8.242.08.1/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz.sha256.txt"
+      }
+    ]
+  },
+  {
     "release_name": "amazon-corretto-11.0.3.7.1",
     "binaries": [
       {
@@ -165,6 +186,18 @@
         "binary_link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz",
         "heap_size": "normal",
         "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz.sha256.txt"
+      }]
+  },
+  {
+    "release_name": "amazon-corretto-11.0.6.10.1-2",
+    "binaries": [
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "openjdk_impl": "hotspot",
+        "binary_link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz",
+        "heap_size": "normal",
+        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz.sha256.txt"
       }]
   }
 ]


### PR DESCRIPTION
Changelogs:
* https://github.com/corretto/corretto-8/blob/1a1a02e62547c5902a7af39772e48c0188e43b93/CHANGELOG.md#corretto-version-8242081
* https://github.com/corretto/corretto-11/blob/develop/CHANGELOG.md#corretto-version-1106101-2-macos

Releases:
* https://github.com/corretto/corretto-11/releases/tag/11.0.6.10.1-2
* https://github.com/corretto/corretto-8/releases/tag/8.242.08.1-1
* https://github.com/corretto/corretto-8/releases/tag/8.242.08.1