### PR TITLE
Fix ShellCheck warnings and make script more strict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,4 +30,4 @@ jobs:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         . asdf/asdf.sh
-        asdf plugin-test java "$GITHUB_WORKSPACE" --asdf-plugin-gitref "$GITHUB_SHA"
+        asdf plugin-test java "$GITHUB_WORKSPACE" --asdf-plugin-gitref "$GITHUB_SHA" --asdf-tool-version azul-zulu-8.44.0.11-jdk8.0.242

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: mstksg/get-package@v1
       with:
-        brew: coreutils jq
-        apt-get: jq
+        brew: coreutils jq shellcheck
+        apt-get: jq shellcheck
+    - name: Run ShellCheck
+      run: |
+        shellcheck -V
+        shellcheck ./bin/functions
     - name: Install asdf
       uses: actions/checkout@v2
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test java "$TRAVIS_BUILD_DIR" --asdf-plugin-gitref "$TRAVIS_COMMIT"
+script: asdf plugin-test java "$TRAVIS_BUILD_DIR" --asdf-plugin-gitref "$TRAVIS_COMMIT" --asdf-tool-version azul-zulu-8.44.0.11-jdk8.0.242
 before_script:
 - git clone https://github.com/asdf-vm/asdf.git
 - . asdf/asdf.sh

--- a/bin/functions
+++ b/bin/functions
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
+set -e
+set -Euo pipefail
 
-PLUGIN_HOME=$(dirname $(dirname "${0}"))
+PLUGIN_HOME="$(dirname "$(dirname "${0}")")"
 CACHE_DIR="${TMPDIR:-/tmp/}asdf-java.cache"
-mkdir -p ${CACHE_DIR}
+trap 'rm -rf ${TEMP_DIR}' EXIT
+
+if [ ! -d "${CACHE_DIR}" ]
+then
+    mkdir -p "${CACHE_DIR}"
+fi
 
 case $(uname -s) in
     Darwin) OS="mac"
@@ -17,29 +24,15 @@ case $(uname -s) in
            ;;
 esac
 
-case ${ASDF_INSTALL_VERSION} in
-    *_large-heap) RELEASE=${ASDF_INSTALL_VERSION%%_large-heap}
-                  HEAP_SIZE="large"
-                  ;;
-    *) RELEASE=${ASDF_INSTALL_VERSION}
-       HEAP_SIZE="normal"
-       ;;
-esac
-
 case $(uname -m) in
     x86_64) ARCHITECTURE="x64" ;;
 esac
 
-trap "rm -rf ${TEMP_DIR}" EXIT
-
-
 function check-jq() {
-  bold=`tput bold`
-  nc=`tput sgr0`
-  USAGE="Install ${bold}jq${nc} to continue. Aborting."
+  USAGE="Install jq to continue. Aborting."
 
   if ! [ -x "$(command -v jq)" ]; then
-    printf "$USAGE" >&2
+    echo "${USAGE}" >&2
     exit 1;
   fi
 }
@@ -52,24 +45,26 @@ function retrieve-adoptopenjdk() {
           "https://api.adoptopenjdk.net/v2/info/releases/{openjdk12}?type=jdk"
           "https://api.adoptopenjdk.net/v2/info/releases/{openjdk13}?type=jdk")
 
-    if [[ -z "$(ls -A ${CACHE_DIR}/adopt-*.json)" ]] || [[  $(set -- $(${STAT}) && echo ${1}) -le $(( `date +%s` - 3600)) ]]
+    # shellcheck disable=SC2046
+    if [[ -z "$(ls -A "${CACHE_DIR}"/adopt-*.json 2>/dev/null)" ]] || [[ $(set -- $(${STAT}) && echo "${1}") -le $(( $(date +%s) - 3600)) ]]
     then
         for url in "${URLS[@]}"
         do
-            curl -s -L ${url} -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" 2>&1 >> /dev/null
+            curl -s -L "${url}" -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" > /dev/null 2>&1
         done
-        for i in `ls ${CACHE_DIR}/adopt-*.json`
+        for i in "${CACHE_DIR}"/adopt-*.json
         do
+            [[ -e "$i" ]] || break
             jq '(.[].release_name) |= sub("jdk-";"adopt-openjdk-") | (.[].release_name) |= sub("^jdk";"adopt-openjdk-")' \
-               ${i} > ${i}.temp
-            mv ${i}.temp ${i}
+               "${i}" > "${i}.temp"
+            mv "${i}.temp" "${i}"
         done
     fi
 }
 
 function retrieve-sapmachine() {
     args=('-s' '-f')
-    if [ -n "$GITHUB_API_TOKEN" ]; then
+    if [[ -n "${GITHUB_API_TOKEN:-}" ]]; then
         args+=('-H' "Authorization: token $GITHUB_API_TOKEN")
     fi
     local cache_file="${CACHE_DIR}/sapmachine.json"
@@ -91,7 +86,8 @@ function retrieve-sapmachine() {
     }
   ]}
 ]'
-    if [[ -z "$(ls -A ${cache_file})" ]] || [[  $(set -- $(${STAT}) && echo ${1}) -le $(( `date +%s` - 3600)) ]]
+    # shellcheck disable=SC2046
+    if [[ ! -r "${cache_file}" ]] || [[  $(set -- $(${STAT}) && echo "${1}") -le $(( $(date +%s) - 3600)) ]]
     then
         curl "${args[@]}" -L 'https://api.github.com/repos/SAP/SapMachine/releases' -o "${cache_file}"
         jq "${filter}" "${cache_file}" > "${cache_file}.temp"
@@ -102,7 +98,7 @@ function retrieve-sapmachine() {
 
 function all-json() {
   check-jq
-  jq -s 'add' ${CACHE_DIR}/*.json ${PLUGIN_HOME}/corretto/corretto.json ${PLUGIN_HOME}/zulu/zulu.json
+  jq -s 'add' "${CACHE_DIR}"/*.json "${PLUGIN_HOME}"/corretto/corretto.json "${PLUGIN_HOME}"/zulu/zulu.json
 }
 
 
@@ -116,6 +112,7 @@ function list-all() {
                               | map(.release_name) | unique[] | select(contains(\"openj9\"))"
     local openj9_large_heap="map(select(.binaries[].heap_size == \"large\")) \
                              | map(.release_name + \"_large-heap\") | unique[] | select(contains(\"openj9\"))"
+    # shellcheck disable=SC2046
     echo $(all-json | jq -r "${hotspot}" ; all-json | jq -r "${openj9_normal_heap}" ; all-json | jq -r "${openj9_large_heap}")
 }
 
@@ -125,44 +122,57 @@ function list-legacy-filenames() {
 
 function install {
     check-jq
+    case "${ASDF_INSTALL_VERSION}" in
+        *_large-heap) RELEASE="${ASDF_INSTALL_VERSION%%_large-heap}"
+                      HEAP_SIZE="large"
+                      ;;
+        *) RELEASE="${ASDF_INSTALL_VERSION}"
+           HEAP_SIZE="normal"
+           ;;
+    esac
+
     retrieve-adoptopenjdk
     retrieve-sapmachine
     local select_release="map(select(.release_name==\"${RELEASE}\")) | unique[] | .binaries[]"
     local select_binary="select(.os==\"${OS}\" and .architecture==\"${ARCHITECTURE}\" and .heap_size==\"${HEAP_SIZE}\")"
-    local binary=$(all-json | jq "$select_release | $select_binary")
-    local binary_link=$(set -- $(echo ${binary} | jq -r ".binary_link") ; echo ${1})
-    local checksum_link=$(set -- $(echo ${binary} | jq -r ".checksum_link") ; echo ${1})
+    local binary
+    local binary_link
+    local checksum_link
+    binary=$(all-json | jq "$select_release | $select_binary")
+    binary_link=$(set -- "$(echo "${binary}" | jq -r ".binary_link")" ; echo "${1}")
+    checksum_link=$(set -- "$(echo "${binary}" | jq -r ".checksum_link")" ; echo "${1}")
 
-    cd ${TEMP_DIR}
-    curl -LO -# -w "%{filename_effective}\n" ${binary_link}
-    if [ $? -ne 0 ]
+    cd "${TEMP_DIR}"
+    if ! curl -LO -# -w "%{filename_effective}\n" "${binary_link}";
     then
         exit 1
     fi
 
-    curl -LO -# -w "%{filename_effective}\n" ${checksum_link}
-    if [ $? -ne 0 ]
+    if ! curl -LO -# -w "%{filename_effective}\n" "${checksum_link}";
     then
         exit 1
     fi
 
-    ${SHA256SUM} -c $(basename ${checksum_link})
+    ${SHA256SUM} -c "$(basename "${checksum_link}")"
 
-    tar zxf $(basename ${binary_link})
-    dir=$(set -- $(ls -d */) ; echo ${1})
-    cd ${dir}
-    mkdir -p ${ASDF_INSTALL_PATH}
+    tar -zxf "$(basename "${binary_link}")"
+    dir=$(set -- "$(ls -d ./*/)" ; echo "${1}")
+    cd "${dir}"
+    if [ ! -d "${ASDF_INSTALL_PATH}" ]
+    then
+        mkdir -p "${ASDF_INSTALL_PATH}"
+    fi
 
     case ${OS} in
         mac) case ${RELEASE} in
-                 azul*) mv * ${ASDF_INSTALL_PATH} ;;
-                 *) mv Contents/Home/* ${ASDF_INSTALL_PATH} ;;
+                 azul*) mv ./* "${ASDF_INSTALL_PATH}" ;;
+                 *) mv Contents/Home/* "${ASDF_INSTALL_PATH}" ;;
              esac ;;
-        *) mv * ${ASDF_INSTALL_PATH} ;;
+        *) mv ./* "${ASDF_INSTALL_PATH}" ;;
     esac
 }
 
-case `basename ${0}` in
+case "$(basename "${0}")" in
     list-all) list-all
               ;;
     list-legacy-filenames) list-legacy-filenames


### PR DESCRIPTION
This change set fixes all [ShellCheck](https://github.com/koalaman/shellcheck) warnings and errors in `bin/functions`.

<details>
Fixed warnings and errors:

```text
> shellcheck bin/functions

In bin/functions line 3:
PLUGIN_HOME=$(dirname $(dirname "${0}"))
                      ^---------------^ SC2046: Quote this to prevent word splitting.


In bin/functions line 33:
trap "rm -rf ${TEMP_DIR}" EXIT
             ^---------^ SC2064: Use single quotes, otherwise this expands now rather than when signalled.


In bin/functions line 37:
  bold=`tput bold`
       ^---------^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
  bold=$(tput bold)


In bin/functions line 38:
  nc=`tput sgr0`
     ^---------^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
  nc=$(tput sgr0)


In bin/functions line 42:
    printf "$USAGE" >&2
           ^------^ SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In bin/functions line 55:
    if [[ -z "$(ls -A ${CACHE_DIR})" ]] || [[  $(set -- $(${STAT}) && echo ${1}) -le $(( `date +%s` - 3600)) ]]
                                                        ^--------^ SC2046: Quote this to prevent word splitting.
                                                                           ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                                                                         ^--------^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
    if [[ -z "$(ls -A ${CACHE_DIR})" ]] || [[  $(set -- $(${STAT}) && echo "${1}") -le $(( $(date +%s) - 3600)) ]]


In bin/functions line 59:
            curl -s -L ${url} -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" 2>&1 >> /dev/null
                       ^----^ SC2086: Double quote to prevent globbing and word splitting.
                                                                                              ^--^ SC2069: To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).

Did you mean:
            curl -s -L "${url}" -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" 2>&1 >> /dev/null


In bin/functions line 61:
        for i in `ls ${CACHE_DIR}`
                 ^---------------^ SC2045: Iterating over ls output is fragile. Use globs.
                 ^---------------^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
        for i in $(ls ${CACHE_DIR})


In bin/functions line 64:
               ${CACHE_DIR}/${i} > ${CACHE_DIR}/${i}.temp
                            ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                                ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
               ${CACHE_DIR}/"${i}" > ${CACHE_DIR}/"${i}".temp


In bin/functions line 65:
            mv ${CACHE_DIR}/${i}.temp ${CACHE_DIR}/${i}
                            ^--^ SC2086: Double quote to prevent globbing and word splitting.
                                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
            mv ${CACHE_DIR}/"${i}".temp ${CACHE_DIR}/"${i}"


In bin/functions line 72:
  jq -s 'add' ${CACHE_DIR}/*.json ${PLUGIN_HOME}/corretto/corretto.json ${PLUGIN_HOME}/zulu/zulu.json
                                  ^------------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                        ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
  jq -s 'add' ${CACHE_DIR}/*.json "${PLUGIN_HOME}"/corretto/corretto.json "${PLUGIN_HOME}"/zulu/zulu.json


In bin/functions line 85:
    echo $(all-json | jq -r "${hotspot}" ; all-json | jq -r "${openj9_normal_heap}" ; all-json | jq -r "${openj9_large_heap}")
         ^-- SC2046: Quote this to prevent word splitting.


In bin/functions line 97:
    local binary=$(all-json | jq "$select_release | $select_binary")
          ^----^ SC2155: Declare and assign separately to avoid masking return values.


In bin/functions line 98:
    local binary_link=$(set -- $(echo ${binary} | jq -r ".binary_link") ; echo ${1})
          ^---------^ SC2155: Declare and assign separately to avoid masking return values.
                               ^-- SC2046: Quote this to prevent word splitting.
                                      ^-------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                               ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    local binary_link=$(set -- $(echo "${binary}" | jq -r ".binary_link") ; echo "${1}")


In bin/functions line 99:
    local checksum_link=$(set -- $(echo ${binary} | jq -r ".checksum_link") ; echo ${1})
          ^-----------^ SC2155: Declare and assign separately to avoid masking return values.
                                 ^-- SC2046: Quote this to prevent word splitting.
                                        ^-------^ SC2086: Double quote to prevent globbing and word splitting.
                                                                                   ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    local checksum_link=$(set -- $(echo "${binary}" | jq -r ".checksum_link") ; echo "${1}")


In bin/functions line 101:
    cd ${TEMP_DIR}
    ^------------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
       ^---------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    cd "${TEMP_DIR}" || exit


In bin/functions line 102:
    curl -LO -# -w "%{filename_effective}\n" ${binary_link}
                                             ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    curl -LO -# -w "%{filename_effective}\n" "${binary_link}"


In bin/functions line 103:
    if [ $? -ne 0 ]
         ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In bin/functions line 108:
    curl -LO -# -w "%{filename_effective}\n" ${checksum_link}
                                             ^--------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    curl -LO -# -w "%{filename_effective}\n" "${checksum_link}"


In bin/functions line 109:
    if [ $? -ne 0 ]
         ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In bin/functions line 114:
    ${SHA256SUM} -c $(basename ${checksum_link})
                    ^--------------------------^ SC2046: Quote this to prevent word splitting.
                               ^--------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    ${SHA256SUM} -c $(basename "${checksum_link}")


In bin/functions line 116:
    tar zxf $(basename ${binary_link})
            ^------------------------^ SC2046: Quote this to prevent word splitting.
                       ^------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    tar zxf $(basename "${binary_link}")


In bin/functions line 117:
    dir=$(set -- $(ls -d */) ; echo ${1})
                 ^---------^ SC2046: Quote this to prevent word splitting.
                         ^-- SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options.
                                    ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    dir=$(set -- $(ls -d */) ; echo "${1}")


In bin/functions line 118:
    cd ${dir}
    ^-------^ SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
       ^----^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    cd "${dir}" || exit


In bin/functions line 119:
    mkdir -p ${ASDF_INSTALL_PATH}
             ^------------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    mkdir -p "${ASDF_INSTALL_PATH}"


In bin/functions line 123:
                 azul*) mv * ${ASDF_INSTALL_PATH} ;;
                           ^-- SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options.
                             ^------------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
                 azul*) mv * "${ASDF_INSTALL_PATH}" ;;


In bin/functions line 124:
                 *) mv Contents/Home/* ${ASDF_INSTALL_PATH} ;;
                                       ^------------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
                 *) mv Contents/Home/* "${ASDF_INSTALL_PATH}" ;;


In bin/functions line 126:
        *) mv * ${ASDF_INSTALL_PATH} ;;
              ^-- SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options.
                ^------------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
        *) mv * "${ASDF_INSTALL_PATH}" ;;


In bin/functions line 130:
case `basename ${0}` in
     ^-------------^ SC2006: Use $(...) notation instead of legacy backticked `...`.
               ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
case $(basename "${0}") in

For more information:
  https://www.shellcheck.net/wiki/SC2045 -- Iterating over ls output is fragi...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2064 -- Use single quotes, otherwise this...
```
</details>

Changes from pull request #44 (support for SapMachine) are included in this PR.
I will rebase it on current `master` if PR #44 has been merged before this PR.