### PR TITLE
Migrate to AdoptOpenJDK API v3

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -38,19 +38,19 @@ function check-jq() {
 }
 
 function retrieve-adoptopenjdk() {
-    URLS=("https://api.adoptopenjdk.net/v2/info/releases/{openjdk8}?type=jdk"
-          "https://api.adoptopenjdk.net/v2/info/releases/{openjdk9}?type=jdk"
-          "https://api.adoptopenjdk.net/v2/info/releases/{openjdk10}?type=jdk"
-          "https://api.adoptopenjdk.net/v2/info/releases/{openjdk11}?type=jdk"
-          "https://api.adoptopenjdk.net/v2/info/releases/{openjdk12}?type=jdk"
-          "https://api.adoptopenjdk.net/v2/info/releases/{openjdk13}?type=jdk")
+    URLS=("https://api.adoptopenjdk.net/v3/assets/feature_releases/{8}/ga?architecture=${ARCHITECTURE}&os=${OS}&image_type=jdk&page=0&page_size=100&project=jdk&sort_order=ASC&vendor=adoptopenjdk"
+          "https://api.adoptopenjdk.net/v3/assets/feature_releases/{9}/ga?architecture=${ARCHITECTURE}&os=${OS}&image_type=jdk&page=0&page_size=100&project=jdk&sort_order=ASC&vendor=adoptopenjdk"
+          "https://api.adoptopenjdk.net/v3/assets/feature_releases/{10}/ga?architecture=${ARCHITECTURE}&os=${OS}&image_type=jdk&page=0&page_size=100&project=jdk&sort_order=ASC&vendor=adoptopenjdk"
+          "https://api.adoptopenjdk.net/v3/assets/feature_releases/{11}/ga?architecture=${ARCHITECTURE}&os=${OS}&image_type=jdk&page=0&page_size=100&project=jdk&sort_order=ASC&vendor=adoptopenjdk"
+          "https://api.adoptopenjdk.net/v3/assets/feature_releases/{12}/ga?architecture=${ARCHITECTURE}&os=${OS}&image_type=jdk&page=0&page_size=100&project=jdk&sort_order=ASC&vendor=adoptopenjdk"
+          "https://api.adoptopenjdk.net/v3/assets/feature_releases/{13}/ga?architecture=${ARCHITECTURE}&os=${OS}&image_type=jdk&page=0&page_size=100&project=jdk&sort_order=ASC&vendor=adoptopenjdk")
 
     # shellcheck disable=SC2046
     if [[ -z "$(ls -A "${CACHE_DIR}"/adopt-*.json 2>/dev/null)" ]] || [[ $(set -- $(${STAT}) && echo "${1}") -le $(( $(date +%s) - 3600)) ]]
     then
         for url in "${URLS[@]}"
         do
-            curl -s -L "${url}" -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" > /dev/null 2>&1
+            curl -f -s -H "Accept: application/json" -L "${url}" -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" > /dev/null 2>&1
         done
         for i in "${CACHE_DIR}"/adopt-*.json
         do
@@ -77,11 +77,13 @@ function retrieve-sapmachine() {
     | select(.name | startswith("sapmachine-jdk"))
     | select(.name | endswith("linux-x64_bin.tar.gz") or endswith("osx-x64_bin.tar.gz"))
     | {
-      binary_link: .browser_download_url,
-      checksum_link: (.browser_download_url | sub("tar\\.gz$"; "sha256.txt")),
+      package: {
+        binary_link: .browser_download_url,
+        checksum_link: (.browser_download_url | sub("tar\\.gz$"; "sha256.txt"))
+      },
       os: (if .name | endswith("osx-x64_bin.tar.gz") then "mac" else "linux" end),
       architecture: "x64",
-      openjdk_impl: "hotspot",
+      jvm_impl: "hotspot",
       heap_size: "normal"
     }
   ]}
@@ -106,7 +108,7 @@ function list-all() {
     check-jq
     retrieve-adoptopenjdk
     retrieve-sapmachine
-    local hotspot="map(select(.binaries[].openjdk_impl == \"hotspot\")) \
+    local hotspot="map(select(.binaries[].jvm_impl == \"hotspot\")) \
                    | map(.release_name) | unique[]"
     local openj9_normal_heap="map(select(.binaries[].heap_size == \"normal\")) \
                               | map(.release_name) | unique[] | select(contains(\"openj9\"))"
@@ -139,8 +141,8 @@ function install {
     local binary_link
     local checksum_link
     binary=$(all-json | jq "$select_release | $select_binary")
-    binary_link=$(set -- "$(echo "${binary}" | jq -r ".binary_link")" ; echo "${1}")
-    checksum_link=$(set -- "$(echo "${binary}" | jq -r ".checksum_link")" ; echo "${1}")
+    binary_link=$(set -- "$(echo "${binary}" | jq -r ".package.link")" ; echo "${1}")
+    checksum_link=$(set -- "$(echo "${binary}" | jq -r ".package.checksum_link")" ; echo "${1}")
 
     cd "${TEMP_DIR}"
     if ! curl -LO -# -w "%{filename_effective}\n" "${binary_link}";

--- a/bin/functions
+++ b/bin/functions
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -e
+set -Euo pipefail
 
 PLUGIN_HOME="$(dirname "$(dirname "${0}")")"
 CACHE_DIR="${TMPDIR:-/tmp/}asdf-java.cache"
@@ -49,7 +50,7 @@ function retrieve-adoptopenjdk() {
     then
         for url in "${URLS[@]}"
         do
-            curl -skL "${url}" -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" > /dev/null 2>&1
+            curl -s -L "${url}" -# -w "%{filename_effective}\n" -o "${CACHE_DIR}/adopt-#1.json" > /dev/null 2>&1
         done
         for i in "${CACHE_DIR}"/adopt-*.json
         do
@@ -62,7 +63,7 @@ function retrieve-adoptopenjdk() {
 }
 
 function retrieve-sapmachine() {
-    args=('-skfL')
+    args=('-s' '-f')
     if [[ -n "${GITHUB_API_TOKEN:-}" ]]; then
         args+=('-H' "Authorization: token $GITHUB_API_TOKEN")
     fi
@@ -88,7 +89,7 @@ function retrieve-sapmachine() {
     # shellcheck disable=SC2046
     if [[ ! -r "${cache_file}" ]] || [[  $(set -- $(${STAT}) && echo "${1}") -le $(( $(date +%s) - 3600)) ]]
     then
-        curl "${args[@]}" 'https://api.github.com/repos/SAP/SapMachine/releases' -o "${cache_file}"
+        curl "${args[@]}" -L 'https://api.github.com/repos/SAP/SapMachine/releases' -o "${cache_file}"
         jq "${filter}" "${cache_file}" > "${cache_file}.temp"
         mv "${cache_file}.temp" "${cache_file}"
     fi
@@ -142,12 +143,12 @@ function install {
     checksum_link=$(set -- "$(echo "${binary}" | jq -r ".checksum_link")" ; echo "${1}")
 
     cd "${TEMP_DIR}"
-    if ! curl -kLO -# -w "%{filename_effective}\n" "${binary_link}";
+    if ! curl -LO -# -w "%{filename_effective}\n" "${binary_link}";
     then
         exit 1
     fi
 
-    if ! curl -kLO -# -w "%{filename_effective}\n" "${checksum_link}";
+    if ! curl -LO -# -w "%{filename_effective}\n" "${checksum_link}";
     then
         exit 1
     fi

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -5,18 +5,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.212.04.2-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.212.04.2-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.212.04.2-macosx-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.212.04.2-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -26,18 +30,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.1-macosx-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/amazon-corretto-8.232.09.1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -47,10 +55,12 @@
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/8.232.09.2/amazon-corretto-8.232.09.2-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.232.09.2/amazon-corretto-8.232.09.2-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.232.09.2-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -60,18 +70,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.07.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.07.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.07.1-macosx-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.242.07.1/amazon-corretto-8.242.07.1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.07.1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -81,18 +95,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/8.242.08.1/amazon-corretto-8.242.08.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.08.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.242.08.1/amazon-corretto-8.242.08.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.08.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/8.242.08.1/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.242.08.1/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-8.242.08.1-1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -102,19 +120,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://d3pxv6yz143wms.cloudfront.net/11.0.3.7.1/amazon-corretto-11.0.3.7.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.3.7.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://d3pxv6yz143wms.cloudfront.net/11.0.3.7.1/amazon-corretto-11.0.3.7.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.3.7.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://d3pxv6yz143wms.cloudfront.net/11.0.3.7.1/amazon-corretto-11.0.3.7.1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.3.7.1-macosx-x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://d3pxv6yz143wms.cloudfront.net/11.0.3.7.1/amazon-corretto-11.0.3.7.1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.3.7.1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "amazon-corretto-11.0.4.11.1",
@@ -122,19 +145,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "amazon-corretto-11.0.5.10.1",
@@ -142,19 +170,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.5.10.1/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.5.10.1/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.5.10.1/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "amazon-corretto-11.0.5.10.2",
@@ -162,11 +195,14 @@
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.5.10.2/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.5.10.2/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.5.10.2-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "amazon-corretto-11.0.6.10.1",
@@ -174,19 +210,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-linux-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "amazon-corretto-11.0.6.10.1-2",
@@ -194,10 +235,13 @@
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.6.10.1/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/corretto/amazon-corretto-11.0.6.10.1-2-macosx-x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   }
 ]

--- a/zulu/zulu.json
+++ b/zulu/zulu.json
@@ -5,18 +5,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -26,18 +30,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -47,18 +55,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.27.9-ca-jdk13-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.27.9-ca-jdk13-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.27.9-ca-jdk13-macosx_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu13.27.9-ca-jdk13-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -68,18 +80,22 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       }
     ]
   },
@@ -89,19 +105,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-11.35.13-jdk11.0.5",
@@ -109,19 +130,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-11.35.15-jdk11.0.5",
@@ -129,19 +155,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-11.37.17-jdk11.0.6",
@@ -149,19 +180,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulufx-11.35.15-jdk11.0.5",
@@ -169,19 +205,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-fx-jdk11.0.5-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-fx-jdk11.0.5-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-fx-jdk11.0.5-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-fx-jdk11.0.5-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-fx-jdk11.0.5-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-fx-jdk11.0.5-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-fx-jdk11.0.5-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.35.15-ca-fx-jdk11.0.5-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulufx-11.37.19-jdk11.0.6",
@@ -189,19 +230,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.37.19-ca-fx-jdk11.0.6-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.19-ca-fx-jdk11.0.6-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.37.19-ca-fx-jdk11.0.6-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.19-ca-fx-jdk11.0.6-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu11.37.19-ca-fx-jdk11.0.6-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.19-ca-fx-jdk11.0.6-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.37.19-ca-fx-jdk11.0.6-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu11.37.19-ca-fx-jdk11.0.6-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-8.42.0.21-jdk8.0.232",
@@ -209,19 +255,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.21-ca-jdk8.0.232-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.21-ca-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-8.44.0.9-jdk8.0.242",
@@ -229,19 +280,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.9-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.9-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-8.42.0.23-jdk8.0.232",
@@ -249,19 +305,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulufx-8.42.0.23-jdk8.0.232",
@@ -269,19 +330,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-fx-jdk8.0.232-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-fx-jdk8.0.232-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-fx-jdk8.0.232-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-fx-jdk8.0.232-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-fx-jdk8.0.232-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-fx-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-fx-jdk8.0.232-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.42.0.23-ca-fx-jdk8.0.232-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulufx-8.44.0.13-jdk8.0.242",
@@ -289,19 +355,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.13-ca-fx-jdk8.0.242-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.13-ca-fx-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.13-ca-fx-jdk8.0.242-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.13-ca-fx-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.13-ca-fx-jdk8.0.242-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.13-ca-fx-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.13-ca-fx-jdk8.0.242-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.13-ca-fx-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-8.44.0.11-jdk8.0.242",
@@ -309,19 +380,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.11-ca-jdk8.0.242-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.11-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.11-ca-jdk8.0.242-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.11-ca-jdk8.0.242-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.11-ca-jdk8.0.242-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.11-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.44.0.11-ca-jdk8.0.242-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu8.44.0.11-ca-jdk8.0.242-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-7.29.0.5-jdk7.0.222",
@@ -329,11 +405,14 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.29.0.5-ca-jdk7.0.222-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.29.0.5-ca-jdk7.0.222-linux_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu7.29.0.5-ca-jdk7.0.222-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.29.0.5-ca-jdk7.0.222-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-7.34.0.5-jdk7.0.242",
@@ -341,19 +420,24 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.34.0.5-ca-jdk7.0.242-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.34.0.5-ca-jdk7.0.242-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu7.34.0.5-ca-jdk7.0.242-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.34.0.5-ca-jdk7.0.242-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.34.0.5-ca-jdk7.0.242-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.34.0.5-ca-jdk7.0.242-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu7.34.0.5-ca-jdk7.0.242-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.34.0.5-ca-jdk7.0.242-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   },
   {
     "release_name": "azul-zulu-7.36.0.5-jdk7.0.252",
@@ -361,18 +445,23 @@
       {
         "os": "linux",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz.sha256.txt"
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.36.0.5-ca-jdk7.0.252-linux_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
       },
       {
         "os": "mac",
         "architecture": "x64",
-        "openjdk_impl": "hotspot",
-        "binary_link": "https://cdn.azul.com/zulu/bin/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz",
-        "heap_size": "normal",
-        "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz.sha256.txt"
-      }]
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz",
+          "checksum_link": "https://raw.githubusercontent.com/halcyon/asdf-java/master/zulu/zulu7.36.0.5-ca-jdk7.0.252-macosx_x64.tar.gz.sha256.txt"
+        },
+        "heap_size": "normal"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
The AdoptOpenJDK API v2 is deprecated and will eventually be shut down: https://api.adoptopenjdk.net/

Additionally, it currently has problems providing data for OpenJDK 13 in which `https://api.adoptopenjdk.net/v2/info/releases/openjdk13?type=jdk` returns an HTTP response with status 404 (Not Found).

Unfortunately the API response format changed slightly, so that the static data for Zulu Community and Amazon Corretto had to be updated, too.

https://api.adoptopenjdk.net/swagger-ui/
https://github.com/AdoptOpenJDK/openjdk-api-v3

Fixes #54