### PR TITLE
Fix bug due presence of testimage during install

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -133,7 +133,8 @@ function install {
     retrieve-adoptopenjdk
     retrieve-sapmachine
     local select_release="map(select(.release_name==\"${RELEASE}\")) | unique[] | .binaries[]"
-    local select_binary="select(.os==\"${OS}\" and .architecture==\"${ARCHITECTURE}\" and .heap_size==\"${HEAP_SIZE}\")"
+    local select_binary="select(.os==\"${OS}\" and .architecture==\"${ARCHITECTURE}\" and .heap_size==\"${HEAP_SIZE}\")" \
+                         and .openjdk_impl!=\"testimage\")"
     local binary
     local binary_link
     local checksum_link


### PR DESCRIPTION
While trying to install adopt-openjdk-13.0.2+8 the previous version of asdf-java was failing with a curl error.

```
$ asdf install java adopt-openjdk-13.0.2+8               
                                                                                                                                                                                                                                                                                                                                                                                  
OpenJDK13U-testimage_x64_linux_hotspot_13.0.2_8.tar.gz                                                                                                                                                                                  
curl: (3) Illegal characters found in URL
```

The underlying cause of the above error was the presence of test binaries returned by AdoptOpenJDK API.

Example broken unfiltered response:

```
$ binary=$(all-json | jq "$select_release | $select_binary")
$ echo ${binary}

{
    "os": "linux",
    "architecture": "x64",
    "binary_type": "jdk",
    "openjdk_impl": "hotspot",
    "binary_name": "OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz",
    "binary_link": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz",
    "binary_size": 207518686,
    "checksum_link": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jdk_x64_linux_hotspot_13.0.2_8.tar.gz.sha256.txt",
    "version": "13",
    "version_data": {
        "openjdk_version": "13.0.2+8",
        "semver": "13.0.2+8"
    },
    "heap_size": "normal",
    "download_count": 9961,
    "updated_at": "2020-01-20T16:42:52Z"
} {
    "os": "linux",
    "architecture": "x64",
    "binary_type": "jdk",
    "openjdk_impl": "testimage",
    "binary_name": "OpenJDK13U-testimage_x64_linux_hotspot_13.0.2_8.tar.gz",
    "binary_link": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-testimage_x64_linux_hotspot_13.0.2_8.tar.gz",
    "binary_size": 40398990,
    "checksum_link": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-testimage_x64_linux_hotspot_13.0.2_8.tar.gz.sha256.txt",
    "version": "13",
    "version_data": {
        "openjdk_version": "13.0.2+8",
        "semver": "13.0.2+8"
    },
    "heap_size": "normal",
    "download_count": 6,
    "updated_at": "2020-01-20T16:44:23Z"
} 
```

This commit fixes the problem by properly filtering test images.