### PR TITLE
Check that temporary directory exists before deleting

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -3,8 +3,8 @@ set -e
 set -Euo pipefail
 
 PLUGIN_HOME="$(dirname "$(dirname "${0}")")"
-CACHE_DIR="${TMPDIR:-/tmp/}asdf-java.cache"
-trap 'rm -rf ${TEMP_DIR}' EXIT
+CACHE_DIR="${TMPDIR:-/tmp}/asdf-java.cache"
+trap 'test -d "${TEMP_DIR}" && rm -rf "${TEMP_DIR}"' EXIT
 
 if [ ! -d "${CACHE_DIR}" ]
 then


### PR DESCRIPTION
Before deleting the temporary directory (`$TEMP_DIR`) at the end of the script,
make sure that it exists so that we don't accidentally delete the user's home directory.

Fixes #63