### PR TITLE
Amazon Corretto and Azul Zulu 11.0.7 / 8u252b14

### DIFF
--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -243,5 +243,30 @@
         "heap_size": "normal"
       }
     ]
+  },
+  {
+    "release_name": "amazon-corretto-11.0.7.10.1",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.7.10.1/amazon-corretto-11.0.7.10.1-linux-x64.tar.gz",
+          "checksum": "24a487d594d10df540383c4c642444f969a00e616331d3dc3bdc4815ada71c0e"
+        },
+        "heap_size": "normal"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/11.0.7.10.1/amazon-corretto-11.0.7.10.1-macosx-x64.tar.gz",
+          "checksum": "4e7c028b71328ee5853c67563c1f8b3e727f03b9b21c8b88c6dbb4f304a0ad0d"
+        },
+        "heap_size": "normal"
+      }
+    ]
   }
 ]

--- a/corretto/corretto.json
+++ b/corretto/corretto.json
@@ -115,6 +115,31 @@
     ]
   },
   {
+    "release_name": "amazon-corretto-8.252.09.1",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.252.09.1/amazon-corretto-8.252.09.1-linux-x64.tar.gz",
+          "checksum": "7f08bc6097a14424bf09eb693304d48812099f29edb1d7326c6372a85b86b1df"
+        },
+        "heap_size": "normal"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://corretto.aws/downloads/resources/8.252.09.1/amazon-corretto-8.252.09.1-macosx-x64.tar.gz",
+          "checksum": "f0204183832f590689055fcd98366ebb43196c84442a9bcb768ac230"
+        },
+        "heap_size": "normal"
+      }
+    ]
+  },
+  {
     "release_name": "amazon-corretto-11.0.3.7.1",
     "binaries": [
       {

--- a/zulu/zulu.json
+++ b/zulu/zulu.json
@@ -224,6 +224,31 @@
     ]
   },
   {
+    "release_name": "azul-zulu-11.39.15-jdk11.0.7",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-linux_x64.tar.gz",
+          "checksum": "df0de67998ac0c58b3c9e83c86e2a81daca05dc5adc189d942bc5d3f4691e749"
+        },
+        "heap_size": "normal"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-macosx_x64.tar.gz",
+          "checksum": "936505ab1826c5db3dbd09efa0b9b453198860cad38f32881aaea00920cc54d7"
+        },
+        "heap_size": "normal"
+      }
+    ]
+  },
+  {
     "release_name": "azul-zulufx-11.35.15-jdk11.0.5",
     "binaries": [
       {
@@ -268,6 +293,31 @@
         "package": {
           "link": "https://cdn.azul.com/zulu/bin/zulu11.37.19-ca-fx-jdk11.0.6-macosx_x64.tar.gz",
           "checksum": "8ede7dc8570ac3256e2f8cb673d9689be09338c4aa610b54f2c6bba68ea2f616"
+        },
+        "heap_size": "normal"
+      }
+    ]
+  },
+  {
+    "release_name": "azul-zulufx-11.37.19-jdk11.0.6",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-fx-jdk11.0.7-linux_x64.tar.gz",
+          "checksum": "10779acfec2001a069a131ae7e508580792762f9cb54f70bcb29b47c43d84480"
+        },
+        "heap_size": "normal"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-fx-jdk11.0.7-macosx_x64.tar.gz",
+          "checksum": "73f9836c47fe913781e0525f46435e1e8d8e434eb77a12d7bb836ad4633e98d1"
         },
         "heap_size": "normal"
       }

--- a/zulu/zulu.json
+++ b/zulu/zulu.json
@@ -474,6 +474,56 @@
     ]
   },
   {
+    "release_name": "azul-zulufx-8.46.0.19-jdk8.0.252",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-fx-jdk8.0.252-linux_x64.tar.gz",
+          "checksum": "03fa80b425b909c64b20157853d66347839ddff1112cce92ec35aa04dbb3432f"
+        },
+        "heap_size": "normal"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-fx-jdk8.0.252-macosx_x64.tar.gz",
+          "checksum": "daec2a3d07d12c23ca4ccc30f3e734459742275e94578fc1cd674a98586efee6"
+        },
+        "heap_size": "normal"
+      }
+    ]
+  },
+  {
+    "release_name": "azul-zulu-8.46.0.19-jdk8.0.252",
+    "binaries": [
+      {
+        "os": "linux",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-linux_x64.tar.gz",
+          "checksum": "ab8a4194006f12dd48bf7f176ca7879706d3f8fc7d3208313a46cc9ee2270716"
+        },
+        "heap_size": "normal"
+      },
+      {
+        "os": "mac",
+        "architecture": "x64",
+        "jvm_impl": "hotspot",
+        "package": {
+          "link": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-macosx_x64.tar.gz",
+          "checksum": "43570b0a6455a02d25b0c4937164560fdb0a9478f9010c583f510fa80881ce0b"
+        },
+        "heap_size": "normal"
+      }
+    ]
+  },
+  {
     "release_name": "azul-zulu-7.29.0.5-jdk7.0.222",
     "binaries": [
       {


### PR DESCRIPTION
Currently this plugin is not able to list releases from Corretto and Zulu. So they have to be updated manually.

https://github.com/corretto/corretto-8/releases/tag/8.252.09.1
https://github.com/corretto/corretto-11/releases/tag/11.0.7.10.1
https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk
https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk-fx
