### PR TITLE
make set-java-home.bash work with an empty PROMPT_COMMAND

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -11,4 +11,8 @@ prompt_command() {
   asdf_update_java_home
 }
 
-export PROMPT_COMMAND="${PROMPT_COMMAND}; prompt_command"
+if [[ -z "$PROMPT_COMMAND" ]]; then
+  export PROMPT_COMMAND="prompt_command"
+else
+  export PROMPT_COMMAND="${PROMPT_COMMAND}; prompt_command"
+fi


### PR DESCRIPTION
set-java-home.bash is currently not working if the `PROMPT_COMMAND `is empty, because the resulting `PROMPT_COMMAND `would be `; prompt_command`.