### PR TITLE
Update set-java-home.zsh to check directory change

### DIFF
--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,4 +1,9 @@
 asdf_update_java_home() {
+  if [[ $L_PWD == $PWD ]]; then
+    return
+  fi
+  export L_PWD=$PWD
+  
   local java_path
   java_path="$(asdf which java)"
   if [[ -n "${java_path}" ]]; then


### PR DESCRIPTION
Update set-java-home.zsh to only update if the working directory has changed.
This will prevent unnecessary java_home update.