### PR TITLE
Add alternative script location for brew installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ For zsh shell, instead use:
 For fish shell, instead use:
 
 `. ~/.asdf/plugins/java/set-java-home.fish`
+
+Note that the location of the scripts will be different if you installed asdf with a package manager.
+For example, you you have installed asdf using brew, the scripts will be located in
+
+`/usr/local/opt/asdf/plugins/java/`
+
+The commands must be altered accordingly, e.g.
+
+`. /usr/local/opt/asdf/plugins/java/set-java-home.zsh`


### PR DESCRIPTION
The location for the `set-java-home.*` scripts is different when asdf was installed using brew. This adds documentation for this scenario.