### PR TITLE
Allow manual dispatch of update-data workflow

### DIFF
--- a/.github/workflows/update-data.yaml
+++ b/.github/workflows/update-data.yaml
@@ -1,5 +1,6 @@
 name: Update Java release data
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 */8 * * *'
 jobs:


### PR DESCRIPTION
In some situations it might be useful to allow triggering the `update-date` workflow to update the release metadata manually.

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/