### PR TITLE
Reworked setting of bash JAVA_HOME

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -1,19 +1,20 @@
 asdf_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
+  java_path="$(asdf where java)"
   if [[ -n "${java_path}" ]]; then
     export JAVA_HOME
-   JAVA_HOME="$(dirname "$(dirname "$(realpath "${java_path}")")")"
+    JAVA_HOME="${java_path}"
   fi
 }
 
-prompt_command() {
-  if [[ "${PWD}" == "${LAST_PWD}" ]]; then
-    return
-  fi
-  LAST_PWD="${PWD}"
+preexec () {
   asdf_update_java_home
 }
 
-export PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND}; prompt_command}"
-export PROMPT_COMMAND="${PROMPT_COMMAND:-prompt_command}"
+preexec_invoke_exec () {
+    [ -n "${COMP_LINE}" ] && return  # do nothing if completing
+    [ "${BASH_COMMAND}" = "${PROMPT_COMMAND}" ] && return # don't cause a preexec for $PROMPT_COMMAND
+    preexec
+}
+
+trap 'preexec_invoke_exec' DEBUG


### PR DESCRIPTION
This change will set JAVA_HOME before a command is executed, not when
the prompt is displayed. The difference is subtle but it reduces
terminal latency significantly.

I also swapped out the call to asdf which for asdf where to reduce the
amount of work necessary to set the JAVA_HOME as the value provided by
asdf where provides the correct path.

@halcyon from our discussion earlier, I think this change fits a little better and keeps all existing functionality only reducing the amount of latency added to the terminal. 