### PR TITLE
Use BSD stat on macOS even if sha256sum is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Requirements
 - [bash v5.0](https://www.gnu.org/software/bash/)
 - [curl](https://curl.haxx.se/)
-- [sha256sum](https://www.gnu.org/software/coreutils/)
+- [sha256sum](https://www.gnu.org/software/coreutils/) (only on Linux)
 - [unzip](http://infozip.sourceforge.net/UnZip.html)
 - [jq](https://stedolan.github.io/jq/) (only for updating the release data)
 

--- a/bin/functions
+++ b/bin/functions
@@ -10,13 +10,15 @@ KERNEL_NAME="$(uname -s)"
 case "${KERNEL_NAME}" in
     Darwin)
             OS="macosx"
-            SHA256SUM="gsha256sum"
+            SHA256SUM="shasum -a 256"
+            STAT="/usr/bin/stat"
             STAT_OPTS=('-f' '%c')
             TEMP_DIR=$(/usr/bin/mktemp -dt asdf-java)
             ;;
     Linux)
            OS="linux"
            SHA256SUM="sha256sum"
+           STAT="stat"
            STAT_OPTS=('-c' '%Z')
            TEMP_DIR=$(mktemp -dp /tmp asdf-java.XXXXXXXX)
            ;;
@@ -46,7 +48,7 @@ function retrieve-release-data() {
     local cache_file="${CACHE_DIR}/releases.tsv"
 
     # shellcheck disable=SC2046
-    if [[ ! -r "${cache_file}" ]] || (( $(stat "${STAT_OPTS[@]}" "${cache_file}") <= $(date +%s) - 3600 )) ; then
+    if [[ ! -r "${cache_file}" ]] || (( $($STAT "${STAT_OPTS[@]}" "${cache_file}") <= $(date +%s) - 3600 )) ; then
         curl -s -f --compressed -L "https://raw.githubusercontent.com/halcyon/asdf-java/master/data/jdk-${OS}-${ARCHITECTURE}.tsv" -o "${cache_file}"
     fi
 }
@@ -85,7 +87,7 @@ function install {
         exit 1
     fi
 
-    ${SHA256SUM} -c <<<"${checksum} ${package_filename}"
+    ${SHA256SUM} -c <<<"${checksum}  ${package_filename}"
 
     case "${package_filename}" in
         *zip) unzip "${package_filename}"


### PR DESCRIPTION
Fixes #107