### PR TITLE
Silence error that occurs when no global java version is set

### DIFF
--- a/set-java-home.fish
+++ b/set-java-home.fish
@@ -1,5 +1,5 @@
 function asdf_update_java_home --on-event fish_prompt
-  set --local java_path (asdf which java)
+  set --local java_path (asdf which java 2>/dev/null)
   if test -n "$java_path"
     set --local full_path (realpath "$java_path")
     set --local full_path_dir (dirname "$full_path")


### PR DESCRIPTION
After every single command, I've been getting this error: `unknown command: java. Perhaps you have to reshim?`

```> cd ..
unknown command: java. Perhaps you have to reshim?```

```> which java
/usr/bin/java
unknown command: java. Perhaps you have to reshim?
```

etc.

After looking at the hook, I decided to redirect error output to `/dev/null`, and that seems to have resolved this issue for me. So, I figured I would mention this here in case anyone is interested in merging this fix, or if anyone sees a problem with this approach.