### PR TITLE
utils.sh is the correct file name. w/ jasquat

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck source=/dev/null
-source "$ASDF_DIR/lib/utils.bash"
+source "$ASDF_DIR/lib/utils.sh"
 CACHE_DIR="${TMPDIR:-/tmp}/asdf-java.cache"
 
 if [ ! -d "${CACHE_DIR}" ]


### PR DESCRIPTION
this prevents errors/warnings like the following:

````
~/p/p/hot-app main % java -version
/Users/kburnett/.asdf/plugins/java/bin/list-legacy-filenames: line 3: /Users/kburnett/.asdf/lib/utils.bash: No such file or directory
openjdk version "1.8.0_265"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_265-b01)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.265-b01, mixed mode)
````