### PR TITLE
Use fish builtin `realpath`

### DIFF
--- a/set-java-home.fish
+++ b/set-java-home.fish
@@ -1,12 +1,7 @@
-function absolute_dir_path -a name
-    set --local absolute_path (cd (dirname "$name") && pwd)
-    echo "$absolute_path"
-end
-
 function asdf_update_java_home --on-event fish_prompt
   set --local java_path (asdf which java)
   if test -n "$java_path"
-    set --local full_path (absolute_dir_path "$java_path")
+    set --local full_path (realpath "$java_path")
     set -gx JAVA_HOME (dirname "$full_path")
   end
 end

--- a/set-java-home.fish
+++ b/set-java-home.fish
@@ -1,7 +1,7 @@
 function asdf_update_java_home --on-event fish_prompt
   set --local java_path (asdf which java)
   if test -n "$java_path"
-    set --local full_path (realpath "$java_path")
+    set --local full_path (builtin realpath "$java_path")
     set -gx JAVA_HOME (dirname "$full_path")
   end
 end


### PR DESCRIPTION
The `fish` shell has a builtin `realpath`, which should be used for this.

The `absolute_dir_path` function doesn't work as it might be expected to, and instead just traps the user inside the JAVA_HOME directory.

See https://github.com/fish-shell/fish-shell/issues/7780 and closes https://github.com/halcyon/asdf-java/issues/130.