### PR TITLE
Use built-in zsh function to get absolute dir path

### DIFF
--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,7 +1,5 @@
 function absolute_dir_path {
-    local absolute_path
-    absolute_path="$( cd -P "$( dirname "$1" )" && pwd )"
-    echo "$absolute_path"
+    echo "$1:A"
 }
 
 asdf_update_java_home() {

--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,5 +1,5 @@
 function absolute_dir_path {
-    echo "$1:A"
+    echo "$(dirname $1:A)"
 }
 
 asdf_update_java_home() {


### PR DESCRIPTION
This should fix #135 for zsh 
There is no need to change the directory, please see https://linux.die.net/man/1/zshexpn for explanation