### PR TITLE
Add the JVM Implementation after the name of the Vendor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,16 @@ jobs:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         ./update_data.bash
-        grep adoptopenjdk-openj9-11 data/jdk-linux-x86_64.tsv
-        grep adoptopenjdk-openj9-large_heap-11 data/jdk-macosx-x86_64.tsv
-        grep zulu-musl-11 data/jdk-linux-x86_64.tsv
-        grep liberica-javafx-16 data/jdk-linux-arm32-vfp-hflt.tsv
-        grep liberica-lite-11 data/jdk-macosx-x86_64.tsv
+        grep -q adoptopenjdk-openj9-11 data/jdk-linux-x86_64.tsv
+        echo "Found adoptopenjdk-openj9-11"
+        grep -q adoptopenjdk-openj9-large_heap-11 data/jdk-macosx-x86_64.tsv
+        echo "Found adoptopenjdk-openj9-large_heap-11"
+        grep -q zulu-musl-11 data/jdk-linux-x86_64.tsv
+        echo "Found zulu-musl-11 "
+        grep -q liberica-javafx-16 data/jdk-linux-arm32-vfp-hflt.tsv
+        echo "Found liberica-javafx-16"
+        grep -q liberica-lite-11 data/jdk-macosx-x86_64.tsv
+        echo "Found liberica-lite-11"
     - name: macOS Check java_home integration
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,16 @@ jobs:
       run: |
         . asdf/asdf.sh
         asdf plugin-test java "$GITHUB_WORKSPACE" --asdf-plugin-gitref "$GITHUB_SHA" --asdf-tool-version adoptopenjdk-8.0.252+9.1.openj9-0.20.0 java -version
+    - name: Check update_data.bash
+      env:
+        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./update_data.bash
+        grep adoptopenjdk-openj9-11 data/jdk-linux-x86_64.tsv
+        grep adoptopenjdk-openj9-large_heap-11 data/jdk-macosx-x86_64.tsv
+        grep zulu-musl-11 data/jdk-linux-x86_64.tsv
+        grep liberica-javafx-16 data/jdk-linux-arm32-vfp-hflt.tsv
+        grep liberica-lite-11 data/jdk-macosx-x86_64.tsv
     - name: macOS Check java_home integration
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
         echo "Found liberica-javafx-16"
         grep -q liberica-lite-11 data/jdk-macosx-x86_64.tsv
         echo "Found liberica-lite-11"
+        grep "graalvm-21" data/jdk-linux-aarch64.tsv | grep -q -v "graalvm-graalvm-21"
+        echo "Found graalvm-21"
     - name: macOS Check java_home integration
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/update_data.bash
+++ b/update_data.bash
@@ -45,7 +45,7 @@ done
 RELEASE_QUERY='.[]
   | select(.file_type | IN("tar.gz", "zip"))
   | .["features"] = (.features | map(select(IN("musl", "javafx", "lite", "large_heap"))))
-  | [([.vendor, if (.jvm_impl == "hotspot") then empty else .jvm_impl end, if ((.features | length) == 0) then empty else (.features | join("-")) end, .version] | join("-")), .filename, .url, .sha256]
+  | [([.vendor, if (.jvm_impl == "openj9") then .jvm_impl else empty end, if ((.features | length) == 0) then empty else (.features | join("-")) end, .version] | join("-")), .filename, .url, .sha256]
   | @tsv'
 for FILE in "${DATA_DIR}"/*.json
 do

--- a/update_data.bash
+++ b/update_data.bash
@@ -45,7 +45,7 @@ done
 RELEASE_QUERY='.[]
   | select(.file_type | IN("tar.gz", "zip"))
   | .["features"] = (.features | map(select(IN("musl", "javafx", "lite", "large_heap"))))
-  | [([.vendor, if ((.features | length) == 0) then empty else (.features | join("-")) end, .version] | join("-")), .filename, .url, .sha256]
+  | [([.vendor, if (.jvm_impl == "hotspot") then empty else .jvm_impl end, if ((.features | length) == 0) then empty else (.features | join("-")) end, .version] | join("-")), .filename, .url, .sha256]
   | @tsv'
 for FILE in "${DATA_DIR}"/*.json
 do


### PR DESCRIPTION
In order to fix https://github.com/halcyon/asdf-java/issues/46 and https://github.com/halcyon/asdf-java/issues/57 I've added the jvm_impl after the vendor.

Unfortunately this will break the names configured previously in .tools-versions if you had selected one of the openj9 JDK's. Not sure how you can do this backwards compatible.