### PR TITLE
Use built-in zsh function to get absolute dir path take 2

### DIFF
--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,15 +1,9 @@
-function absolute_dir_path {
-    local absolute_path
-    absolute_path="$( cd -P "$( dirname "$1" )" && pwd )"
-    echo "$absolute_path"
-}
-
 asdf_update_java_home() {
   local java_path
   java_path="$(asdf which java)"
   if [[ -n "${java_path}" ]]; then
     export JAVA_HOME
-    JAVA_HOME="$(dirname "$(absolute_dir_path "${java_path}")")"
+    JAVA_HOME="$(dirname "$(dirname "${java_path:A}")")"
   fi
 }
 


### PR DESCRIPTION
As created by @a4z and posted in https://github.com/halcyon/asdf-java/pull/136 this should fix #135 . Since I can't edit the original pull request I made a new one with the requested changes by @halcyon .