### PR TITLE
With the jvm_impl as part of the base name of the package the plugin-test broke

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         . asdf/asdf.sh
-        asdf plugin-test java "$GITHUB_WORKSPACE" --asdf-plugin-gitref "$GITHUB_SHA" --asdf-tool-version adoptopenjdk-8.0.252+9.1.openj9-0.20.0 java -version
+        asdf plugin-test java "$GITHUB_WORKSPACE" --asdf-plugin-gitref "$GITHUB_SHA" --asdf-tool-version adoptopenjdk-openj9-8.0.252+9.1.openj9-0.20.0 java -version
     - name: Check update_data.bash
       env:
         GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With https://github.com/halcyon/asdf-java/pull/140 I missed the fact that it would break the plugin-test step in the tests :(

adoptopenjdk-8.0.252+9.1.openj9-0.20.0 no longer exists, it's now adoptopenjdk-openj9-8.0.252+9.1.openj9-0.20.0

This pull request fixes that.