### PR TITLE
set JAVA_HOME in exec-env

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [ -n "$ASDF_INSTALL_PATH" ]; then
+  export JAVA_HOME="$ASDF_INSTALL_PATH"
+fi


### PR DESCRIPTION
IMHO the plugin should set `JAVA_HOME` for all commands.

Bonus: 

Exporting `JAVA_HOME` in `exec-env` makes the plugin play nice with [asdf-direnv](https://github.com/asdf-community/asdf-direnv)