### PR TITLE
Allow unset ASDF_DIR environment variable

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck source=/dev/null
-source "$ASDF_DIR/lib/utils.bash"
+source "${ASDF_DIR:-$HOME/.asdf}/lib/utils.bash"
 CACHE_DIR="${TMPDIR:-/tmp}/asdf-java.cache"
 
 if [ ! -d "${CACHE_DIR}" ]


### PR DESCRIPTION
Resolves the following error that displays for users who do not set ASDF_DIR:

    $HOME/.asdf/plugins/java/bin/list-all: line 3: /lib/utils.bash: No such file or directory

As indicated in the [official asdf docs][asdf docs], `ASDF_DIR` should default to `~/.asdf`, though asdf itself defaults to `$HOME/.asdf`:

> ASDF_DIR - Defaults to ~/.asdf - Location of the asdf scripts. If you install asdf to some other directory, set this to that directory. For example, if you are installing via the AUR, you should set this to /opt/asdf-vm.

[asdf docs]: http://asdf-vm.com/manage/configuration.html#environment-variables