### PR TITLE
Add guard against Bash versions lower than 5

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -3,6 +3,11 @@
 source "${ASDF_DIR:-$HOME/.asdf}/lib/utils.bash"
 CACHE_DIR="${TMPDIR:-/tmp}/asdf-java.cache"
 
+if [ ! "${BASH_VERSINFO:-0}" -ge 5 ]; then
+  echo "Bash 5 or higher is required for asdf-java"
+  exit 1
+fi
+
 if [ ! -d "${CACHE_DIR}" ]
 then
     mkdir -p "${CACHE_DIR}"


### PR DESCRIPTION
Since you require Bash version 5, but macOS will ship with an outdated version of GNU bash (3) I thought it made sense to exit early and warn the user.

![image](https://user-images.githubusercontent.com/6213695/142890637-0b6fa576-b1a7-4223-bbc4-277b4a86624d.png)

> Last command is default macOS bash, top is brew bash
