### PR TITLE
fix: inital,emtpy setup does not print errors

### DIFF
--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,6 +1,6 @@
 asdf_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
+  java_path="$(asdf which java 2>/dev/null || which java 2>/dev/null)"
   if [[ -n "${java_path}" ]]; then
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(dirname "${java_path:A}")")"


### PR DESCRIPTION
* suppress errors if `asdf java` is not found
* fallback to system java if no shim is yet installed (during initial setup)