### PR TITLE
Return with previous exit code in Bash prompt function

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -15,11 +15,13 @@ function _asdf_java_update_java_home() {
 }
 
 function _asdf_java_prompt_command() {
+  local e=$?
   if [[ "${PWD}" == "${LAST_PWD}" ]]; then
-    return
+    return $e
   fi
   LAST_PWD="${PWD}"
   _asdf_java_update_java_home
+  return $e
 }
 
 if ! [[ "${PROMPT_COMMAND:-}" =~ _asdf_java_prompt_command ]]; then


### PR DESCRIPTION
asdf-java prepends to `$PROMPT_COMMAND`, thus swallowing up the previous command's exit code (normally the command the user invoked). This is troublesome if the exit code is used in the user's own prompt command, for example to output a different prompt.