### PR TITLE
Removes silent fail from retrieve-release-data()

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -61,7 +61,7 @@ function retrieve-release-data() {
             *) url="$base_url-ga.tsv" ;;
         esac
 
-        curl -s -f --compressed -L "${url}" -o "${cache_file}"
+        curl -sS --compressed -L "${url}" -o "${cache_file}"
     fi
 }
 


### PR DESCRIPTION
Updates `retrieve-release-data()` to no longer silently fail, this was causing issues where I was having SSL issues, but could not diagnose them.

Current behavior:
``` console
$ asdf list-all java
No compatible versions available (java )

$ asdf install java liberica-1.8.0
grep: /tmp/asdf-java.cache/releases-linux-x86_64.tsv: No such file or directory
Unknown release: liberica-1.8.0
```

Proposed behaviour:
``` console
$ asdf install java liberica-1.8.0
curl: (60) SSL certificate problem: self-signed certificate in certificate chain
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
grep: /tmp/asdf-java.cache/releases-linux-x86_64.tsv: No such file or directory
Unknown release: liberica-1.8.0
```

I believe this would have also brought some clarity to #173 and #190.