### PR TITLE
Create cache dir for currently logged in user

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -64,7 +64,7 @@ get_asdf_config_value() {
 }
 ### <<<<<<
 
-CACHE_DIR="${TMPDIR:-/tmp}/asdf-java.cache"
+CACHE_DIR="${TMPDIR:-/tmp}/asdf-java-${whoami}.cache"
 
 if [ ! -d "${CACHE_DIR}" ]
 then


### PR DESCRIPTION
In a multi user environment it's possible that some other user has already created CACHE_DIR with its own permissions breaking this plugin. Add currently logged in user name into CACHE_DIR directory name so that it would be user specific and have correct permissions for every user