### PR TITLE
Update set-java-home.xsh

### DIFF
--- a/set-java-home.xsh
+++ b/set-java-home.xsh
@@ -1,11 +1,10 @@
 #!/usr/bin/env xonsh
 
 def asdf_update_java_home() -> None:
-    $java_path=$(asdf which java)
-    if len($java_path) > 0:
-        $JAVA_HOME=$(dirname $(dirname $(realpath $java_path))).rstrip('\n')
+    java_path=$(asdf which java).rstrip('\n')
+    if java_path:
+        $JAVA_HOME=$(dirname $(dirname $(realpath @(java_path)))).rstrip('\n')
         $JDK_HOME=$JAVA_HOME
-    del $java_path
 
 @events.on_chdir
 def update_java_home_on_chdir(olddir, newdir, **kw) -> None:


### PR DESCRIPTION
The [process substitution operator $() returns output with universal new lines][1] which must be stripped - $(asdf which java) returns the path name including a trailing \n; feeding that to realpath gives the error message "No such file or directory".

Replaced the temporary environment variable `$java_path` with a local java variable `java_path` (without the $), the variable automatically gets discarded at the end of the scope and does not need an explicit `del`.

Replaced `if len(java_path) > 0` by the equivalent but more [pythonic][2] `if java_path`.

[1]: https://github.com/anki-code/xonsh-cheatsheet#3-the-process-substitution-operator--returns-output-with-universal-new-lines
[2]: https://docs.python.org/3/library/stdtypes.html#truth-value-testing