### PR TITLE
Do not show "No version is set for command java" without global Java configuration and no Java version set locally

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -6,7 +6,7 @@ function _asdf_java_absolute_dir_path {
 
 function _asdf_java_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
+  java_path="$(asdf which java 2>/dev/null)"
   if [[ -n "${java_path}" ]]; then
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(_asdf_java_absolute_dir_path "${java_path}")")"


### PR DESCRIPTION
Having following conditions met:
1. asdf java plugin has been installed
2. `set-java-home.bash` sourced in `~/.bashrc` 
3. No global Java version has been configured in `~/.tool-versions`
4. No local Java version configured in local directory or shell

Then opening a new terminal window or moving between directories causes the following annoying message to be shown every time:
```
No version is set for command java
Consider adding one of the following versions in your config file at 
java temurin-22.0.1+8
```

This PR hides this message by redirecting stderr of `asdf which java` command used by `set-java-home.bash` to `/dev/null`.

Similar problem probably exists for other supported shells, but since I don't use these then I can't test any changes.