### PR TITLE
Unset JAVA_HOME and JDK_HOME when no java version set by asdf

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -11,6 +11,9 @@ function _asdf_java_update_java_home() {
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(_asdf_java_absolute_dir_path "${java_path}")")"
     export JDK_HOME=${JAVA_HOME}
+  else
+    unset JAVA_HOME
+    unset JDK_HOME
   fi
 }
 


### PR DESCRIPTION
Currently `JAVA_HOME` and `JDK_HOME` variables are set by `set-java-home.bash` when Java version is specified by asdf. This might cause `JAVA_HOME` and `JDK_HOME` to be persisted even when Java version is not specified anymore (for example navigating out of directory with local `.tool-versions` file).

For example:
```
~$ echo $JAVA_HOME

~$ cd project
~/project$ cat .tool-versions 
java temurin-22.0.1+8
~/project$ echo $JAVA_HOME 
/home/user/.asdf/installs/java/temurin-22.0.1+8
~/project$ cd ..
~$ echo $JAVA_HOME 
/home/user/.asdf/installs/java/temurin-22.0.1+8
```

This PR clears JAVA_HOME when it is not configured via asdf to keep it in sync. Similar problem probably exists for other supported shells, but since I don't use these then I can't test any changes.