### PR TITLE
Support tgz file type

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -169,6 +169,8 @@ function install {
               ;;
         *tar.gz) tar xf "${package_filename}"
                  ;;
+        *tgz) tar xf "${package_filename}"
+                 ;;
         *) echo "Cannot extract ${package_filename}"
            exit 1
            ;;

--- a/update_data.bash
+++ b/update_data.bash
@@ -51,7 +51,7 @@ do
 done
 
 RELEASE_QUERY='.[]
-  | select(.file_type | IN("tar.gz", "zip"))
+  | select(.file_type | IN("tar.gz", "tgz", "zip"))
   | .["features"] = (.features | map(select(IN("musl", "javafx", "lite", "large_heap"))))
   | [([.vendor, if (.image_type == "jre") then .image_type else empty end, if (.jvm_impl == "openj9") then .jvm_impl else empty end, if ((.features | length) == 0) then empty else (.features | join("-")) end, .version] | join("-")), .filename, .url, .sha256]
   | @tsv'


### PR DESCRIPTION
- IBM archives come as tgz.
- implements #235
- tested with `asdf install java ibm-openj9-8.0.8.30`

Thanks for looking into this.