### PR TITLE
Fail install command if download extraction errors out

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -174,6 +174,11 @@ function install {
            ;;
     esac
 
+    if [ $? -ne 0 ]; then
+        echo "Failed to extract ${package_filename}"
+        exit 1
+    fi
+
     read -r -a dirs <<<"$(ls -d ./*/)"
     cd "${dirs[0]}" || return 1
     if [ ! -d "${ASDF_INSTALL_PATH}" ]; then


### PR DESCRIPTION
We encountered an issue this morning where a [Github incident](https://www.githubstatus.com/incidents/fnq063tqh7cc) caused release artifact URLs to briefly return invalid content (the `tar.gz` file just had HTML instead). Even though the `tar` extraction failed, the overall `install` didn't and created bad cache entries in our CI system.