### PR TITLE
update: "plugin-add" with "plugin add" syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Install
 
 ```
-asdf plugin-add java https://github.com/halcyon/asdf-java.git
+asdf plugin add java https://github.com/halcyon/asdf-java.git
 ```
 
 ## Use
@@ -26,7 +26,7 @@ Check [asdf](https://asdf-vm.github.io/asdf/) for instructions on how to install
 List candidate JDKs:
 
 ```
-asdf list-all java
+asdf list all java
 ```
 
 Install a candidate listed from the previous command like this:


### PR DESCRIPTION

![plugin-add](https://github.com/user-attachments/assets/b75b2723-5fb4-4398-9059-77bdc48625ef)
![list-all](https://github.com/user-attachments/assets/a152a8f9-03e9-4860-8dc6-463a0ae16562)

The syntax with "-" in "plugin-add" and "asdf list-all" is no longer accepted, as it now only triggers the asdf help command.

Changes:
- Replaced all instances of "plugin-add" with "plugin add" in scripts and configurations.