### PR TITLE
Fix: depreciated command of nushell script

### DIFF
--- a/set-java-home.nu
+++ b/set-java-home.nu
@@ -5,7 +5,7 @@ def asdf_update_java_home [] {
         let $full_path = (realpath $java_path | lines | nth 0 | str trim)
 
         let $java_home = ($full_path | path dirname | path dirname)
-        let-env JAVA_HOME = $java_home
-        let-env JDK_HOME = $java_home
+        $env.JAVA_HOME = $java_home
+        $env.JDK_HOME = $java_home
     }
 }


### PR DESCRIPTION
`let-env` is depreciated in nushell, and leads to an error.