### PR TITLE
Add ASDF_ARCH env var to override architecture detection

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -93,14 +93,18 @@ esac
 
 trap 'test -d "${TEMP_DIR}" && rm -rf "${TEMP_DIR}"' EXIT
 
-MACHINE="$(uname -m)"
-case "${MACHINE}" in
-    x86_64) ARCHITECTURE="x86_64" ;;
-    aarch64|arm64) ARCHITECTURE="aarch64" ;;
-    armv7l) ARCHITECTURE="arm32-vfp-hflt" ;;
-    *) echo "Unknown machine architecture: ${MACHINE}"
-       exit 1
-esac
+if [[ -n "${ASDF_ARCH}" ]]; then
+    ARCHITECTURE="${ASDF_ARCH}"
+else
+    MACHINE="$(uname -m)"
+    case "${MACHINE}" in
+        x86_64) ARCHITECTURE="x86_64" ;;
+        aarch64|arm64) ARCHITECTURE="aarch64" ;;
+        armv7l) ARCHITECTURE="arm32-vfp-hflt" ;;
+        *) echo "Unknown machine architecture: ${MACHINE}"
+           exit 1
+    esac
+fi
 
 function check-unzip() {
   USAGE="Install unzip to continue. Aborting."


### PR DESCRIPTION
## Summary

- Adds `ASDF_ARCH` environment variable to override the architecture detected from `uname -m`
- When unset, behaviour is identical to before — architecture is auto-detected as usual
- When set, the value is used directly as `ARCHITECTURE`, bypassing `uname` detection

## Use case: x86_64 JDK on Apple Silicon macOS for JNI with native-only libraries

Some Java libraries ship JNI (Java Native Interface) bindings that include native `.dylib` or `.so` files compiled only for x86_64. On Apple Silicon (aarch64) Macs, the JVM will load these native libraries at runtime — but if the library has no arm64 slice, the load fails with `UnsatisfiedLinkError`.

The correct fix is to run the entire JVM as x86_64 under Rosetta 2, so all native library loads go through the x86_64 path. This requires installing an x86_64 JDK on an aarch64 machine.

Previously the only workaround was to spawn a Rosetta shell first:
```bash
arch -x86_64 /bin/zsh
asdf install java <version>
```

With this change you can install an x86_64 JDK directly:
```bash
ASDF_ARCH=x86_64 asdf list all java
ASDF_ARCH=x86_64 asdf install java adoptopenjdk-17.0.14+7
```

Then set it as the runtime for the project:
```bash
ASDF_ARCH=x86_64 asdf local java adoptopenjdk-17.0.14+7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)