### PR TITLE
Fix set-java-home scripts to check exit code of asdf which java

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -6,8 +6,7 @@ function _asdf_java_absolute_dir_path {
 
 function _asdf_java_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
-  if [[ -n "${java_path}" ]]; then
+  if java_path="$(asdf which java 2>/dev/null)" && [[ -n "${java_path}" ]]; then
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(_asdf_java_absolute_dir_path "${java_path}")")"
     export JDK_HOME=${JAVA_HOME}

--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,7 +1,6 @@
 asdf_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
-  if [[ -n "${java_path}" ]]; then
+  if java_path="$(asdf which java 2>/dev/null)" && [[ -n "${java_path}" ]]; then
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(dirname "${java_path:A}")")"
     export JDK_HOME=${JAVA_HOME}


### PR DESCRIPTION
## Problem

`asdf which java` writes its error message to **stdout** instead of stderr when no java version is configured:

```zsh
$ java_path="$(asdf which java 2>/dev/null)"
$ echo "java_path='$java_path'"
java_path='unexpected error: no versions set for java'
```

Because `set-java-home.zsh` and `set-java-home.bash` check `[[ -n "${java_path}" ]]`, the non-empty error string causes the guard to pass. In the zsh case this leads to a silently wrong, **directory-dependent `JAVA_HOME`** via the `:A` path modifier resolving the error string relative to `$PWD`:

```
~
❯ grails -version
ERROR: JAVA_HOME is set to an invalid directory: /Users

~/src/myproject
❯ grails -version
ERROR: JAVA_HOME is set to an invalid directory: /Users/me/src
```

## Fix

Check the exit code of `asdf which java` in addition to the non-empty string check. `asdf which java` exits with code 1 on failure, so combining the assignment with `&&` short-circuits correctly even when the error text leaks into stdout.

```zsh
# before
java_path="$(asdf which java)"
if [[ -n "${java_path}" ]]; then

# after
if java_path="$(asdf which java 2>/dev/null)" && [[ -n "${java_path}" ]]; then
```

Closes #266