### PR TITLE
Fix set-java-home.zsh to unset JAVA_HOME when no java version is set

### DIFF
--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -5,6 +5,9 @@ asdf_update_java_home() {
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(dirname "${java_path:A}")")"
     export JDK_HOME=${JAVA_HOME}
+  else
+    unset JAVA_HOME
+    unset JDK_HOME
   fi
 }
 


### PR DESCRIPTION
## Problem

`set-java-home.zsh` is missing the `else` branch that `set-java-home.bash` has. When `asdf which java` returns no valid path, the bash version correctly clears `JAVA_HOME` and `JDK_HOME`, but the zsh version leaves them with whatever value they had before.

**set-java-home.bash** (correct):
```bash
if [[ -n "${java_path}" ]]; then
    export JAVA_HOME
    ...
else
    unset JAVA_HOME
    unset JDK_HOME
fi
```

**set-java-home.zsh** (missing else):
```zsh
if [[ -n "${java_path}" ]]; then
    export JAVA_HOME
    ...
fi
# JAVA_HOME left stale when java_path is empty
```

## Fix

Add the missing `else` branch to match the bash version's behaviour.

Closes #267