### PR TITLE
Recreate top-level symlinks for Zulu macOS installs

### DIFF
--- a/bin/functions
+++ b/bin/functions
@@ -192,6 +192,17 @@ function install {
             case ${ASDF_INSTALL_VERSION} in
                 zulu*)
                     mv ./* "${ASDF_INSTALL_PATH}"
+                    # Recent Zulu macOS archives ship only `Contents/` at the root.
+                    # Older archives also included top-level convenience symlinks
+                    # (`bin`, `conf`, ...) pointing into `Contents/Home/`. asdf shims
+                    # expect `${ASDF_INSTALL_PATH}/bin/java`, so create them when missing.
+                    if [ ! -e "${ASDF_INSTALL_PATH}/bin" ] && [ -d "${ASDF_INSTALL_PATH}/Contents/Home" ]; then
+                        local entry name
+                        for entry in "${ASDF_INSTALL_PATH}/Contents/Home"/*; do
+                            name="$(basename "${entry}")"
+                            ln -s "Contents/Home/${name}" "${ASDF_INSTALL_PATH}/${name}"
+                        done
+                    fi
                     if [ "$(get_asdf_config_value "java_macos_integration_enable")" = "yes" ]; then
                         local macOS_integration_path
                         macOS_integration_path="$(dirname "$(dirname "$(dirname "$(absolute_dir_path "${ASDF_INSTALL_PATH}/bin/..")")")")"


### PR DESCRIPTION
## Problem

Recent Zulu macOS archives ship only `Contents/` at the root, dropping the top-level convenience symlinks (`bin`, `conf`, `lib`, …) older archives included. For example, `zulu21.50.19-ca-jdk21.0.11-macosx_aarch64.tar.gz` extracts to:

```
zulu21.50.19-ca-jdk21.0.11-macosx_aarch64/
└── Contents/
    ├── _CodeSignature/
    ├── Home/         (the actual JDK contents — bin/, lib/, conf/, …)
    ├── Info.plist
    └── MacOS/
```

The `zulu*` install branch in `bin/functions` does `mv ./* "${ASDF_INSTALL_PATH}"`, which now moves only `Contents/` into the install path. asdf shims look for `${ASDF_INSTALL_PATH}/bin/java`, so without the top-level symlinks pointing into `Contents/Home/`, the install exits 0 but is silently unusable — `asdf list java` shows the version as not-fully-installed, and `java --version` reports `No version is set for command java` for any tool-version pinned to a recent Zulu.

I reproduced this on macOS 15 (Sequoia) ARM with multiple recent Zulu builds — `zulu-17.66.19`, `zulu-21.50.19`, `zulu-26.30.11` — using both the `.zip` and `.tar.gz` variants Azul ships. Older Zulu archives (e.g. `zulu-17.44.53`) shipped the top-level symlinks alongside a `zulu-XX.jdk/` directory, so installs created before the archive format change still work.

## Fix

After `mv ./*`, if `${ASDF_INSTALL_PATH}/bin` doesn't exist and `${ASDF_INSTALL_PATH}/Contents/Home` does, create the top-level symlinks pointing into `Contents/Home/`. Older archives that already include the symlinks are unaffected — the guard skips the loop entirely.

This preserves the install layout `java_macos_integration_install` expects (`${ASDF_INSTALL_PATH}/Contents/MacOS` and `Info.plist` are still present), so `java_macos_integration_enable=yes` continues to work.

## Verification

```bash
asdf uninstall java zulu-26.30.11
asdf install java zulu-26.30.11
ls ~/.asdf/installs/java/zulu-26.30.11/
# bin -> Contents/Home/bin
# conf -> Contents/Home/conf
# Contents
# demo -> Contents/Home/demo
# DISCLAIMER -> Contents/Home/DISCLAIMER
# include -> Contents/Home/include
# jmods -> Contents/Home/jmods
# legal -> Contents/Home/legal
# lib -> Contents/Home/lib
# man -> Contents/Home/man
# readme.txt -> Contents/Home/readme.txt
# release -> Contents/Home/release
~/.asdf/installs/java/zulu-26.30.11/bin/java --version
# openjdk 26.0.1 2026-04-21 …
```

Pre-fix: same install command leaves only `Contents/` in the install dir and `java --version` reports "no version set".
