### PR TITLE
fix(nushell): register set-java-home as hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For fish shell, instead use:
 
 `. ~/.asdf/plugins/java/set-java-home.fish`
 
-For nushell shell, instead use:
+For nushell shell, add the following to `config.nu`:
 
 `source ~/.asdf/plugins/java/set-java-home.nu`
 

--- a/set-java-home.nu
+++ b/set-java-home.nu
@@ -1,11 +1,15 @@
-def asdf_update_java_home [] {
-    let $java_path = (asdf which java)
-
-    if $java_path {
-        let $full_path = (realpath $java_path | lines | nth 0 | str trim)
-
-        let $java_home = ($full_path | path dirname | path dirname)
-        $env.JAVA_HOME = $java_home
-        $env.JDK_HOME = $java_home
+def --env asdf-update-java-home [] {
+    let java_path = asdf which java | complete
+    if $java_path.exit_code == 0 {
+        let full_path = ($java_path.stdout | str trim | path expand)
+        let java_home = ($full_path | path dirname | path dirname)
+        if $java_home != ($env.JAVA_HOME? | default "") {
+            $env.JAVA_HOME = $java_home
+            $env.JDK_HOME = $java_home
+        }
     }
 }
+
+$env.config.hooks.pre_prompt = (
+  $env.config.hooks | get -o pre_prompt | default [] | prepend {|| asdf-update-java-home }
+)


### PR DESCRIPTION
## Problem

  The current `set-java-home.nu` defines `asdf_update_java_home` but never invokes it and never registers it as a hook. As a result, sourcing the script is a no-op:
  `JAVA_HOME` and `JDK_HOME` are simply never set.

  ## Proposal
  
Follow the pattern already established for other shells:
  - Make the function an `--env` function so it can actually mutate the caller's environment
  - Register it as a hook so the values track the active java version as the user moves around