### PR TITLE
Handle if asdf which java errors

### DIFF
--- a/set-java-home.bash
+++ b/set-java-home.bash
@@ -6,8 +6,7 @@ function _asdf_java_absolute_dir_path {
 
 function _asdf_java_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
-  if [[ -n "${java_path}" ]]; then
+  if java_path=$(asdf which java 2>&1) && [[ -n $java_path ]]; then
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(_asdf_java_absolute_dir_path "${java_path}")")"
     export JDK_HOME=${JAVA_HOME}

--- a/set-java-home.zsh
+++ b/set-java-home.zsh
@@ -1,7 +1,6 @@
 asdf_update_java_home() {
   local java_path
-  java_path="$(asdf which java)"
-  if [[ -n "${java_path}" ]]; then
+  if java_path=$(asdf which java 2>&1) && [[ -n $java_path ]]; then
     export JAVA_HOME
     JAVA_HOME="$(dirname "$(dirname "${java_path:A}")")"
     export JDK_HOME=${JAVA_HOME}


### PR DESCRIPTION
If the java plugin is installed but no java version has been installed yet, the `asdf which java` command will error.

This changes the bash and zsh code to handle this error and treat it as if java is not installed.

I'm only familiar with bash and zsh, so I am not sure if this issue also affects other shell types.